### PR TITLE
Fix Database URI

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,6 +43,9 @@ from functools import wraps
 # create a Flask app and setup its configuration
 app = Flask(__name__)
 app.secret_key = "76^)(HEY,BULK-MAILER-HERE!)(skh390880213%^*&%6h&^&69lkjw*&kjh"
+DATABASE_URI = config("DATABASE_URL")
+if DATABASE_URI.startswith("postgres://"):
+    DATABASE_URI = DATABASE_URI.replace("postgres://", "postgresql://", 1)
 app.config["SQLALCHEMY_DATABASE_URI"] = config("DATABASE_URL")
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db = SQLAlchemy(app)


### PR DESCRIPTION
## Related Issue 

- Info about the related issue 

Closes: #163 

### Describe the changes you've made

Give a clear description what modifications you have made
Heroku by default provides the database uri as postgres://
But it should be like postgresql://

## Type of change

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Mention any unusual behaviour of your code (Write NA if not)
Any unusual behaviour of your code

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly whereever it was hard to understand.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I am a GSSOC Participant.

## Additional Info (optional)
Any additional information you want to give